### PR TITLE
Logic for removing the option to apply for an individual terminusName…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bytetrade/core",
-    "version": "0.3.58",
+    "version": "0.3.59",
     "description": "didvault core module",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/src/name.ts
+++ b/src/name.ts
@@ -19,11 +19,7 @@ export function getTerminusNameFromVC(type: string, name: string): string {
 		if (s.length != 2) {
 			return undefined;
 		}
-		if (
-			s[1] != 'gmail.com' &&
-			s[1] != 'bytetrade.io' &&
-			s[1] != 'bytetradelab.io'
-		) {
+		if (s[1] != 'gmail.com') {
 			return undefined;
 		}
 		let n = '';

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -14,7 +14,7 @@ describe('testing index file', () => {
 		expect(getTerminusNameFromVC('Google', '.a.a-a.a.@gmail.com')).toBe(
 			'aaaa'
 		);
-		expect(getTerminusNameFromVC('Google', '.a.a-a.a.@bytetrade.io')).toBe(
+		expect(getTerminusNameFromVC('Google', '.a.a-a.a.@gmail.com')).toBe(
 			'aaaa'
 		);
 		expect(getTerminusNameFromVC('Google', 'azngpeng.1@gmail.com')).toBe(


### PR DESCRIPTION
Logic for removing the option to apply for an individual terminusName using bytetrade.io and bytetradelab.io