### PR TITLE
feat: add Olares version compare method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bytetrade/core",
-  "version": "0.3.78",
+  "version": "0.3.79",
   "description": "didvault core module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/basic.ts
+++ b/src/basic.ts
@@ -24,4 +24,56 @@ export const DefaultTerminusInfo: TerminusInfo = {
 	terminusd: '0'
 };
 
+export const compareOlaresVersion = (version0: string, version1: string) => {
+	const version0Splits = version0.split('-');
+	const version1Splits = version1.split('-');
+
+	const result = {
+		compare: 0
+	};
+
+	if (version0Splits.length != version1Splits.length) {
+		result.compare = version0Splits.length > version1Splits.length ? -1 : 1;
+	} else if (version0Splits.length > 1 || version1Splits.length > 1) {
+		const v0ISRc = version0Splits[1].startsWith('rc');
+		const v1ISRc = version1Splits[1].startsWith('rc');
+		if (v0ISRc && v1ISRc) {
+			result.compare =
+				Number(version0Splits[1].replace('rc.', '')) >
+				Number(version1Splits[1].replace('rc.', ''))
+					? 1
+					: -1;
+		} else if (!v0ISRc && !v1ISRc) {
+			result.compare =
+				Number(version0Splits[1]) > Number(version1Splits[1]) ? 1 : -1;
+		} else {
+			result.compare = v0ISRc ? 1 : -1;
+		}
+	}
+
+	const v0Parts = version0Splits[0].split('.').map(Number);
+	const v1Parts = version1Splits[0].split('.').map(Number);
+
+	const maxLength = Math.max(v0Parts.length, v1Parts.length);
+
+	while (v0Parts.length < maxLength) {
+		v0Parts.push(0);
+	}
+	while (v1Parts.length < maxLength) {
+		v1Parts.push(0);
+	}
+
+	for (let i = 0; i < maxLength; i++) {
+		if (v0Parts[i] > v1Parts[i]) {
+			result.compare = 1;
+			break;
+		} else if (v0Parts[i] < v1Parts[i]) {
+			result.compare = -1;
+			break;
+		}
+	}
+
+	return result;
+};
+
 export const TerminusDefaultDomain = 'olares.com';


### PR DESCRIPTION
const testCompareList = [
    ['1.0.0-rc.1', '1.0.0-rc.2'],
    ['1.0.0-rc.1', '1.0.0'],
    ['1.0.0-20250310', '1.0.0-20250311'],
    ['1.0.0', '1.0.0-20250311'],
    ['1.0.0-rc.1', '1.0.0-20250311'],
    ['1.0.1', '1.0.2'],
    ['1.0.1', '1.0.1'],
    ['1.1', '1.0.1']
];
for (const [version0, version1] of testCompareList) {
    const result = compareOlaresVersion(version0, version1);
    console.log(`Comparing ${version0} and ${version1}:`, result);
}

Comparing 1.0.0-rc.1 and 1.0.0-rc.2: { compare: -1 }
Comparing 1.0.0-rc.1 and 1.0.0: { compare: -1 }
Comparing 1.0.0-20250310 and 1.0.0-20250311: { compare: -1 }
Comparing 1.0.0 and 1.0.0-20250311: { compare: 1 }
Comparing 1.0.0-rc.1 and 1.0.0-20250311: { compare: 1 }
Comparing 1.0.1 and 1.0.2: { compare: -1 }
Comparing 1.0.1 and 1.0.1: { compare: 0 }
Comparing 1.1 and 1.0.1: { compare: 1 }